### PR TITLE
Handle empty sigs and fix ROI division by zero

### DIFF
--- a/src/snipe/api/multisig_reference_QC.py
+++ b/src/snipe/api/multisig_reference_QC.py
@@ -381,6 +381,10 @@ class MultiSigReferenceQC:
         if sample_sig._type != SigType.SAMPLE:
             self.logger.error("Invalid signature type for sample_sig: %s | %s", sample_sig.sigtype, sample_sig._type)
             raise ValueError(f"sample_sig must be of type {SigType.SAMPLE}, got {sample_sig.sigtype}")
+        
+        if len(sample_sig) == 0:
+            e_msg = f"Sample signature is empty. This might be coming from sketching reads with length < {sample_sig.ksize}, or super small sample."
+            raise ValueError(e_msg)
 
         
         # ============= SAMPLE STATS =============
@@ -845,7 +849,14 @@ class MultiSigReferenceQC:
                     reference_sig=roi_reference_sig,
                     enable_logging=self.enable_logging
                 )
-                cumulative_stats = cumulative_qc.get_aggregated_stats()
+                
+                # use MultiSigQC instead of ReferenceQC
+                cumulative_stats = self.process_sample(
+                    sample_sig=cumulative_snipe_sig,
+                    predict_extra_folds=None,
+                    advanced=False
+                )
+                
                 cumulative_coverage_index = cumulative_stats.get("Genome coverage index", 0.0)
                 cumulative_total_abundance = cumulative_total_abundances[i]
 

--- a/src/snipe/cli/cli_ops.py
+++ b/src/snipe/cli/cli_ops.py
@@ -1145,18 +1145,9 @@ def guided_merge(ctx, table, output_dir, reset_abundance, trim_singletons,
                 report.write("-"*50 + "\n")
                 report.write("Merged Signatures:\n")
                 if result['merged_signatures']:
-                    for sig in result['merged_signatures']:
-                        report.write(f"    - {sig}\n")
-                else:
-                    report.write("    None\n")
-
-                report.write("Skipped Signatures (Due to Duplication):\n")
+                    report.write("    - " + "\n    - ".join(result['merged_signatures']) + "\n")
                 if result['skipped_signatures']:
-                    for sig in result['skipped_signatures']:
-                        report.write(f"    - {sig}\n")
-                else:
-                    report.write("    None\n")
-
+                    report.write(f"Skipped Signatures (Due to Duplication): {' -'.join(result['skipped_signatures'])}\n")
                 report.write(f"Output File: {result['output_file'] if result['output_file'] else 'N/A'}\n")
                 report.write(f"Status: {result['status'].capitalize()}\n")
                 if result['status'] == 'failure':


### PR DESCRIPTION
- ROI now not dependent on the old `ReferenceQC` class.
- Minified `snipe ops guided-merge` report.